### PR TITLE
Fixes #189 : It's might be a bug

### DIFF
--- a/Dopamine.Common/Resources/Styles/ContextMenu.xaml
+++ b/Dopamine.Common/Resources/Styles/ContextMenu.xaml
@@ -8,6 +8,7 @@
     
     <!-- Separator -->
     <Style TargetType="{x:Type Separator}" x:Key="{x:Static MenuItem.SeparatorStyleKey}">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="Height" Value="1" />
         <Setter Property="Margin" Value="5,0,5,0"/>
         <Setter Property="Template">
@@ -21,6 +22,7 @@
 
     <!--Outer menu items-->
     <Style TargetType="{x:Type MenuItem}">
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="Foreground" Value="{DynamicResource RG_BlackBrush}"/>
         <Style.Triggers>
@@ -32,8 +34,9 @@
     </Style>
 
     <!-- Outer menu -->
-    <Style x:Key="ContextMenuStyle" TargetType="{x:Type ContextMenu}">
+    <Style TargetType="{x:Type ContextMenu}">
         <Setter Property="OverridesDefaultStyle" Value="True" />
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="FontSize" Value="12" />
         <Setter Property="Template">
             <Setter.Value>
@@ -55,8 +58,6 @@
             </Setter.Value>
         </Setter>
     </Style>
-    <Style TargetType="{x:Type ContextMenu}" BasedOn="{StaticResource ContextMenuStyle}"/>
-
 
     <!-- SubmenuItem -->
     <ControlTemplate x:Key="{x:Static MenuItem.SubmenuItemTemplateKey}" TargetType="{x:Type MenuItem}">

--- a/Dopamine.Common/Resources/Styles/MetroTextBox.xaml
+++ b/Dopamine.Common/Resources/Styles/MetroTextBox.xaml
@@ -1,10 +1,6 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="/Dopamine.Common;component/Resources/Styles/ContextMenu.xaml" />
-    </ResourceDictionary.MergedDictionaries>
-
     <Style x:Key="MetroTextBox" TargetType="{x:Type TextBox}">
         <Setter Property="Background" Value="{DynamicResource RG_ControlsBackgroundMediumBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource RG_ForegroundBrush}" />
@@ -14,7 +10,7 @@
         <Setter Property="SnapsToDevicePixels" Value="True"/>
         <Setter Property="ContextMenu">
             <Setter.Value>
-                <ContextMenu Style="{DynamicResource ContextMenuStyle}">
+                <ContextMenu>
                     <MenuItem Command="ApplicationCommands.Cut"/>
                     <MenuItem Command="ApplicationCommands.Copy"/>
                     <MenuItem Command="ApplicationCommands.Paste"/>
@@ -46,7 +42,7 @@
         <Setter Property="VerticalContentAlignment" Value="Top" />
         <Setter Property="ContextMenu">
             <Setter.Value>
-                <ContextMenu Style="{DynamicResource ContextMenuStyle}">
+                <ContextMenu>
                     <MenuItem Command="ApplicationCommands.Cut"/>
                     <MenuItem Command="ApplicationCommands.Copy"/>
                     <MenuItem Command="ApplicationCommands.Paste"/>
@@ -73,11 +69,10 @@
         <Setter Property="Background" Value="{DynamicResource RG_ControlsBackgroundMediumBrush}" />
         <Setter Property="Foreground" Value="{DynamicResource RG_ForegroundBrush}" />
         <Setter Property="SelectionBrush" Value="{DynamicResource RG_AccentBrush}" />
-        <Setter Property="OverridesDefaultStyle" Value="True" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="ContextMenu">
             <Setter.Value>
-                <ContextMenu Style="{DynamicResource ContextMenuStyle}">
+                <ContextMenu>
                     <MenuItem Command="ApplicationCommands.Paste"/>
                 </ContextMenu>
             </Setter.Value>

--- a/Dopamine.Common/Themes/AccentTextBox.xaml
+++ b/Dopamine.Common/Themes/AccentTextBox.xaml
@@ -5,7 +5,6 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Dopamine.Common;component/Resources/Styles/FontStyles.xaml" />
-        <ResourceDictionary Source="/Dopamine.Common;component/Resources/Styles/ContextMenu.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <converters:BooleanToCollapsedConverter x:Key="BooleanToCollapsedConverter" />
@@ -16,7 +15,7 @@
         <Setter Property="SelectionBrush" Value="{DynamicResource RG_AccentBrush}" />
         <Setter Property="ContextMenu">
             <Setter.Value>
-                <ContextMenu Style="{DynamicResource ContextMenuStyle}">
+                <ContextMenu>
                     <MenuItem Command="ApplicationCommands.Cut"/>
                     <MenuItem Command="ApplicationCommands.Copy"/>
                     <MenuItem Command="ApplicationCommands.Paste"/>

--- a/Dopamine.Common/Themes/SearchBox.xaml
+++ b/Dopamine.Common/Themes/SearchBox.xaml
@@ -4,7 +4,6 @@
 
     <ResourceDictionary.MergedDictionaries>
         <ResourceDictionary Source="/Dopamine.Common;component/Resources/Styles/FontStyles.xaml" />
-        <ResourceDictionary Source="/Dopamine.Common;component/Resources/Styles/ContextMenu.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style x:Key="{x:Type controls:SearchBox}" TargetType="{x:Type controls:SearchBox}">
@@ -12,7 +11,7 @@
         <Setter Property="SelectionBrush" Value="{DynamicResource RG_AccentBrush}"/>
         <Setter Property="ContextMenu">
             <Setter.Value>
-                <ContextMenu Style="{DynamicResource ContextMenuStyle}">
+                <ContextMenu>
                     <MenuItem Command="ApplicationCommands.Cut"/>
                     <MenuItem Command="ApplicationCommands.Copy"/>
                     <MenuItem Command="ApplicationCommands.Paste"/>


### PR DESCRIPTION
Or it might a feature.
Actually, ContextMenu Property need to be set explicitly, but its style dosen't.
Someone has the same problem [at here](https://social.msdn.microsoft.com/Forums/vstudio/en-US/7067a875-7ba3-4d58-83d3-552326675be0/contextmenu-style-not-working-for-textbox-and-combobox-controls?forum=wpf)