### PR TITLE
fix a missed property in VerticalVolumeControls

### DIFF
--- a/Dopamine.Presentation/Views/VerticalVolumeControls.xaml
+++ b/Dopamine.Presentation/Views/VerticalVolumeControls.xaml
@@ -11,7 +11,7 @@
                                  prismMvvm:ViewModelLocator.AutoWireViewModel="True">
 
     <StackPanel VerticalAlignment="Center" Background="#00000000" HorizontalAlignment="Center" Width="30" PreviewMouseWheel="StackPanel_PreviewMouseWheel">
-        <dc:VerticalUWPSlider Height="50" Value="{Binding VolumeValue,Mode=TwoWay}" Maximum="1" TrackBackground="{DynamicResource RG_SliderTrackBackgroundBrush}" ButtonBackground="{DynamicResource RG_ForegroundBrush}" BarBackground="{DynamicResource RG_AccentBrush}" ChangeValueWhileDragging="True"/>
+        <dc:VerticalUWPSlider Height="50" Value="{Binding VolumeValue,Mode=TwoWay}" Maximum="1" TrackBackground="{DynamicResource RG_SliderTrackBackgroundBrush}" ButtonInnerBackground="{DynamicResource RG_WindowBackgroundBrush}" ButtonBackground="{DynamicResource RG_ForegroundBrush}" BarBackground="{DynamicResource RG_AccentBrush}" ChangeValueWhileDragging="True"/>
         <Label Padding="0" Content="{Binding VolumeValuePercent}" Margin="0,10,0,0" FontSize="{x:Static base:Constants.GlobalFontSize}" HorizontalContentAlignment="Center" Foreground="{DynamicResource RG_ForegroundBrush}"/>
     </StackPanel>
 </baseviews:VolumeControlViewBase>

--- a/Dopamine.Services/Dopamine.Services.csproj
+++ b/Dopamine.Services/Dopamine.Services.csproj
@@ -103,7 +103,7 @@
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="Windows">
-      <HintPath>..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\Windows.winmd</HintPath>
+      <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\Windows.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />


### PR DESCRIPTION
Otherwise, the button of the slider cannot be clicked due to its 'null' brush.