### PR TITLE
Optimizes spectrum analyzer performance

### DIFF
--- a/Dopamine.Core/Audio/SpectrumAnalyzer.cs
+++ b/Dopamine.Core/Audio/SpectrumAnalyzer.cs
@@ -306,81 +306,68 @@ namespace Dopamine.Core.Audio
         private void UpdateSpectrumShapes()
         {
             bool allZero = true;
-            double fftBucketHeight = 0f;
-            double barHeight = 0f;
-            double lastPeakHeight = 0f;
-            double peakYPos = 0f;
-            double height = spectrumCanvas.RenderSize.Height;
-            int barIndex = 0;
+            double height = spectrumCanvas.RenderSize.Height, dbValue = 0d, barHeight = 0d, xCoord = 0d;
+            float tPeek = 0f;
+            double barWidth = this.BarWidth, barSpacing = this.BarSpacing;
 
-            for (int i = this.minimumFrequencyIndex; i <= this.maximumFrequencyIndex; i++)
+            for (var barIndex = 0; barIndex < barIndexMax.Length; barIndex++)
             {
+                var i = barIndexMax[barIndex];
+                barHeight = 0d;
+
                 // If we're paused, keep drawing, but set the current height to 0 so the peaks fall.
-                if (!this.soundPlayer.IsPlaying)
-                {
-                    barHeight = 0f;
-                }
-                else // Draw the maximum value for the bar's band
+                if (this.soundPlayer.IsPlaying)
+                // Draw the maximum value for the bar's band
                 {
                     switch (this.AnimationStyle)
                     {
-                        case SpectrumAnimationStyle.Nervous:
-                            // Do nothing
-                            break;
                         case SpectrumAnimationStyle.Gentle:
                             this.channelData[i] -= 0.003f;
                             break;
+                        // Do nothing
                         default:
                             break;
                     }
 
-                    double dbValue = 20 * Math.Log10((double)this.channelData[i]);
+                    dbValue = 20 * Math.Log10(this.channelData[i]);
 
-                    fftBucketHeight = ((dbValue - minDBValue) / dbScale) * height;
+                    var fftBucketHeight = ((dbValue - minDBValue) / dbScale) * height;
 
                     if (barHeight < fftBucketHeight) barHeight = fftBucketHeight;
                     if (barHeight < 0f) barHeight = 0f;
                 }
 
-                // If this is the last FFT bucket in the bar's group, draw the bar.
-                if (i == this.barIndexMax[barIndex])
+                // Peaks can't surpass the height of the control.
+                if (barHeight > height) barHeight = height;
+
+                tPeek = this.channelPeakData[barIndex];
+                if (tPeek < barHeight)
                 {
-                    // Peaks can't surpass the height of the control.
-                    if (barHeight > height) barHeight = height;
-
-                    peakYPos = barHeight;
-
-                    if (this.channelPeakData[barIndex] < peakYPos)
-                    {
-                        this.channelPeakData[barIndex] = (float)peakYPos;
-                    }
-                    else
-                    {
-                        this.channelPeakData[barIndex] = (float)(peakYPos + (this.peakFallDelay * this.channelPeakData[barIndex])) / ((float)(this.peakFallDelay + 1));
-                    }
-
-                    double xCoord = this.BarSpacing + (this.BarWidth * barIndex) + (this.BarSpacing * barIndex) + 1;
-
-                    switch (this.AnimationStyle)
-                    {
-                        case SpectrumAnimationStyle.Nervous:
-                            this.barShapes[barIndex].Margin = new Thickness(xCoord, (height - 1) - barHeight, 0, 0);
-                            this.barShapes[barIndex].Height = barHeight;
-                            break;
-                        case SpectrumAnimationStyle.Gentle:
-                            this.barShapes[barIndex].Margin = new Thickness(xCoord, (height - 1) - this.channelPeakData[barIndex], 0, 0);
-                            this.barShapes[barIndex].Height = this.channelPeakData[barIndex];
-                            break;
-                        default:
-                            break;
-                    }
-
-                    if (this.channelPeakData[barIndex] > 0.05) allZero = false;
-
-                    lastPeakHeight = barHeight;
-                    barHeight = 0f;
-                    barIndex++;
+                    tPeek = (float)barHeight;
                 }
+                else
+                {
+                    tPeek = (float)(barHeight + (this.peakFallDelay * tPeek)) / ((float)(this.peakFallDelay + 1));
+                }
+
+                xCoord = barSpacing + (barWidth * barIndex) + (barSpacing * barIndex) + 1;
+
+                switch (this.AnimationStyle)
+                {
+                    case SpectrumAnimationStyle.Nervous:
+                        this.barShapes[barIndex].Margin = new Thickness(xCoord, (height - 1) - barHeight, 0, 0);
+                        this.barShapes[barIndex].Height = barHeight;
+                        break;
+                    case SpectrumAnimationStyle.Gentle:
+                        this.barShapes[barIndex].Margin = new Thickness(xCoord, (height - 1) - tPeek, 0, 0);
+                        this.barShapes[barIndex].Height = tPeek;
+                        break;
+                    default:
+                        break;
+                }
+
+                if (tPeek > 0.05) allZero = false;
+                this.channelPeakData[barIndex] = tPeek;
             }
 
             if (!allZero || this.soundPlayer.IsPlaying)


### PR DESCRIPTION
By comparison, it can reduce average 0.5%~1% cpu loads on my laptop and provide a more real-time frequency spectrum.  It now won't compute those useless FFT data. But I'm not sure it behaves on other computers as same as mine and I cannot figure out the reason why frequency spectrum is more real-time. Maybe it can show more fps?