### PR TITLE
Fix Previous/Next media keys when using system notifications and spectrum analyser turned on

### DIFF
--- a/Dopamine/Views/Common/SpectrumAnalyzerControl.xaml.cs
+++ b/Dopamine/Views/Common/SpectrumAnalyzerControl.xaml.cs
@@ -56,7 +56,7 @@ namespace Dopamine.Views.Common
                 return;
             }
 
-            this.SpectrumContainer.Visibility = Visibility.Visible;
+            Application.Current.Dispatcher.Invoke(() => this.SpectrumContainer.Visibility = Visibility.Visible);
 
             if (this.playbackService.Player != null)
             {
@@ -67,7 +67,7 @@ namespace Dopamine.Views.Common
 
         private void UnregisterSpectrumPlayers()
         {
-            this.SpectrumContainer.Visibility = Visibility.Collapsed;
+            Application.Current.Dispatcher.Invoke(() => this.SpectrumContainer.Visibility = Visibility.Collapsed);
 
             if (this.playbackService.Player != null)
             {


### PR DESCRIPTION
This fixes the bug I encountered where the app would glitch out if someone pressed the next/previous media keys with system notifications turned on and spectrum analyzer enabled.