### PR TITLE
Fix crash when the TrackNumber wasn't able to be parsed

### DIFF
--- a/Dopamine/Services/Notification/NotificationService.cs
+++ b/Dopamine/Services/Notification/NotificationService.cs
@@ -10,6 +10,7 @@ using System.Windows;
 using Windows.Media;
 using Windows.Media.Playback;
 using Windows.Storage.Streams;
+using Digimezzo.Foundation.Core.Logging;
 
 namespace Dopamine.Services.Notification
 {
@@ -94,7 +95,8 @@ namespace Dopamine.Services.Notification
             musicProperties.AlbumTitle = track.AlbumTitle;
             musicProperties.Artist = track.ArtistName;
             musicProperties.Title = track.TrackTitle;
-            musicProperties.TrackNumber = Convert.ToUInt32(track.TrackNumber);
+            uint.TryParse(track.TrackNumber, out var trackNumber);
+            musicProperties.TrackNumber = trackNumber;
             await SetArtworkThumbnailAsync(await this.MetadataService.GetArtworkAsync(track.Path));
             displayUpdater.Update();
         }


### PR DESCRIPTION
This fixes the crash when using the system notification and a song has an invalid TrackNumber that can't be parsed to uint.

Also, I had some trouble syncing with upstream (I'm not a git master yet 😄), so a squash and merge might be necessary to keep it clean. Next time I'll do a reset hard and make sure I don't introduce 5 commits just to change one line.