### PR TITLE
Make Dopamine snappier

### DIFF
--- a/Dopamine.Data/Entities/QueuedTrack.cs
+++ b/Dopamine.Data/Entities/QueuedTrack.cs
@@ -4,12 +4,8 @@ namespace Dopamine.Data.Entities
 {
     public class QueuedTrack
     {
-        [PrimaryKey(), AutoIncrement()]
-        public long QueuedTrackID { get; set; }
-
-        public string Path { get; set; }
-
-        public string SafePath { get; set; }
+        [PrimaryKey()]
+        public long TrackID { get; set; }
 
         public long IsPlaying { get; set; }
 
@@ -24,12 +20,12 @@ namespace Dopamine.Data.Entities
                 return false;
             }
 
-            return this.QueuedTrackID.Equals(((QueuedTrack)obj).QueuedTrackID);
+            return TrackID == ((QueuedTrack)obj).TrackID;
         }
 
         public override int GetHashCode()
         {
-            return new { this.QueuedTrackID }.GetHashCode();
+            return TrackID.GetHashCode();
         }
     }
 }

--- a/Dopamine.Data/MetaDataUtils.cs
+++ b/Dopamine.Data/MetaDataUtils.cs
@@ -134,7 +134,7 @@ namespace Dopamine.Data
             return string.IsNullOrWhiteSpace(fileMetadata.Album.Value) ? string.Empty : FormatUtils.TrimValue(fileMetadata.Album.Value);
         }
 
-        public static void FillTrackBase(FileMetadata fileMetadata, ref Track track)
+        public static void FillTrackBase(FileMetadata fileMetadata, Track track)
         {
             track.TrackTitle = FormatUtils.TrimValue(fileMetadata.Title.Value);
             track.Year = SafeConvertToLong(fileMetadata.Year.Value);
@@ -150,7 +150,7 @@ namespace Dopamine.Data
             track.AlbumKey = GenerateInitialAlbumKey(track.AlbumTitle, track.AlbumArtists);
         }
 
-        public static void FillTrack(FileMetadata fileMetadata, ref Track track)
+        public static void FillTrack(FileMetadata fileMetadata, Track track)
         {
             string path = fileMetadata.Path;
             long nowTicks = DateTime.Now.Ticks;
@@ -171,7 +171,7 @@ namespace Dopamine.Data
             track.DateLastSynced = nowTicks;
             track.Rating = fileMetadata.Rating.Value;
 
-            FillTrackBase(fileMetadata, ref track);
+            FillTrackBase(fileMetadata, track);
         }
 
         private static string GenerateInitialAlbumKey(string albumTitle, string albumArtists)
@@ -199,7 +199,7 @@ namespace Dopamine.Data
 
                 await Task.Run(() =>
                 {
-                    MetadataUtils.FillTrack(fileMetadata, ref track);
+                    MetadataUtils.FillTrack(fileMetadata, track);
                 });
             }
 

--- a/Dopamine.Data/Repositories/IQueuedTrackRepository.cs
+++ b/Dopamine.Data/Repositories/IQueuedTrackRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Dopamine.Data.Entities;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -6,8 +7,8 @@ namespace Dopamine.Data.Repositories
 {
     public interface IQueuedTrackRepository
     {
-        Task<List<QueuedTrack>> GetSavedQueuedTracksAsync();
-        Task SaveQueuedTracksAsync(IList<QueuedTrack> tracks);
-        Task<QueuedTrack> GetPlayingTrackAsync();
+        Task<List<Track>> GetSavedQueuedTracksAsync();
+        Task SaveQueuedTracksAsync(IList<Track> tracks, long? currentTrackId, long progressSeconds);
+        Task<Tuple<Track, long>> GetPlayingTrackAsync();
     }
 }

--- a/Dopamine.Data/SQLiteConnectionFactory.cs
+++ b/Dopamine.Data/SQLiteConnectionFactory.cs
@@ -9,9 +9,10 @@ namespace Dopamine.Data
     public class SQLiteConnectionFactory : ISQLiteConnectionFactory
     {
         public string DatabaseFile => Path.Combine(SettingsClient.ApplicationFolder(), ProductInformation.ApplicationName + ".db");
+
         public SQLiteConnection GetConnection()
         {
-            return new SQLiteConnection(this.DatabaseFile) { BusyTimeout = new TimeSpan(0, 0, 0, 10) };
+            return new SQLiteConnection(this.DatabaseFile) { BusyTimeout = TimeSpan.FromSeconds(10) };
         }
     }
 }

--- a/Dopamine.Services/Dopamine.Services.csproj
+++ b/Dopamine.Services/Dopamine.Services.csproj
@@ -171,6 +171,8 @@
     <Compile Include="InfoDownload\InfoDownloadService.cs" />
     <Compile Include="JumpList\IJumpListService.cs" />
     <Compile Include="JumpList\JumpListService.cs" />
+    <Compile Include="Lifetime\TerminationService.cs" />
+    <Compile Include="Lifetime\ITerminationService.cs" />
     <Compile Include="Lifetime\ILifetimeService.cs" />
     <Compile Include="Lifetime\LifetimeService.cs" />
     <Compile Include="Lyrics\ILyricsService.cs" />

--- a/Dopamine.Services/File/FileService.cs
+++ b/Dopamine.Services/File/FileService.cs
@@ -9,13 +9,13 @@ using Dopamine.Data.Repositories;
 using Dopamine.Services.Cache;
 using Dopamine.Services.Entities;
 using Dopamine.Services.Extensions;
+using Dopamine.Services.Lifetime;
 using Prism.Ioc;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.ServiceModel;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Windows;
@@ -26,17 +26,22 @@ namespace Dopamine.Services.File
     public class FileService : IFileService
     {
         private ICacheService cacheService;
+        private ITerminationService cancellationService;
         private ITrackRepository trackRepository;
         private IContainerProvider container;
-        private IList<string> files;
-        private object lockObject = new object();
+        private IList<string> files = new List<string>();
         private Timer addFilesTimer;
         private int addFilesMilliseconds = 250;
         private string instanceGuid;
 
-        public FileService(ICacheService cacheService, ITrackRepository trackRepository, IContainerProvider container)
+        public FileService(
+            ICacheService cacheService,
+            ITerminationService cancellationService,
+            ITrackRepository trackRepository,
+            IContainerProvider container)
         {
             this.cacheService = cacheService;
+            this.cancellationService = cancellationService;
             this.trackRepository = trackRepository;
             this.container = container;
 
@@ -44,7 +49,6 @@ namespace Dopamine.Services.File
             // This prevents the cleanup function to delete artwork which is in use by this instance.
             this.instanceGuid = Guid.NewGuid().ToString();
 
-            this.files = new List<string>();
             this.addFilesTimer = new Timer();
             this.addFilesTimer.Interval = this.addFilesMilliseconds;
             this.addFilesTimer.Elapsed += AddFilesTimerElapsedHandler;
@@ -95,43 +99,40 @@ namespace Dopamine.Services.File
         {
             var tracks = new List<TrackViewModel>();
 
-            await Task.Run(async () =>
+            if (paths == null)
             {
-                if (paths == null)
-                {
-                    return;
-                }
+                return tracks;
+            }
 
-                // Convert the files to tracks
-                foreach (string path in paths)
+            // Convert the files to tracks
+            foreach (string path in paths)
+            {
+                if (FileFormats.IsSupportedAudioFile(path))
                 {
-                    if (FileFormats.IsSupportedAudioFile(path))
+                    // The file is a supported audio format: add it directly.
+                    tracks.Add(await this.CreateTrackAsync(path));
+                }
+                else if (processPlaylistFiles && FileFormats.IsSupportedStaticPlaylistFile(path))
+                {
+                    // The file is a supported playlist format: process the contents of the playlist file.
+                    foreach (string audioFilePath in this.ProcessPlaylistFile(path))
                     {
-                        // The file is a supported audio format: add it directly.
-                        tracks.Add(await this.CreateTrackAsync(path));
-                    }
-                    else if (processPlaylistFiles && FileFormats.IsSupportedStaticPlaylistFile(path))
-                    {
-                        // The file is a supported playlist format: process the contents of the playlist file.
-                        foreach (string audioFilePath in this.ProcessPlaylistFile(path))
-                        {
-                            tracks.Add(await this.CreateTrackAsync(audioFilePath));
-                        }
-                    }
-                    else if (Directory.Exists(path))
-                    {
-                        // The file is a directory: get the audio files in that directory and all its sub directories.
-                        foreach (string audioFilePath in this.ProcessDirectory(path))
-                        {
-                            tracks.Add(await this.CreateTrackAsync(audioFilePath));
-                        }
-                    }
-                    else
-                    {
-                        // The file is unknown: do not process it.
+                        tracks.Add(await this.CreateTrackAsync(audioFilePath));
                     }
                 }
-            });
+                else if (Directory.Exists(path))
+                {
+                    // The file is a directory: get the audio files in that directory and all its sub directories.
+                    foreach (string audioFilePath in await this.ProcessDirectoryAsync(path))
+                    {
+                        tracks.Add(await this.CreateTrackAsync(audioFilePath));
+                    }
+                }
+                else
+                {
+                    // The file is unknown: do not process it.
+                }
+            }
 
             return tracks;
         }
@@ -178,7 +179,7 @@ namespace Dopamine.Services.File
                     // Don't process index=0, as this contains the name of the executable.
                     for (int index = 1; index <= args.Length - 1; index++)
                     {
-                        lock (this.lockObject)
+                        lock (this.files)
                         {
                             this.files.Add(args[index]);
                             LogClient.Info("Added file '{0}'", args[index]);
@@ -204,7 +205,7 @@ namespace Dopamine.Services.File
             // that could mean there are other instances trying to send files to this instance.
             if (EnvironmentUtils.IsSingleInstance(ProductInformation.ApplicationName))
             {
-                lock (this.lockObject)
+                lock (this.files)
                 {
                     LogClient.Info("Finished adding files. Number of files added = {0}", this.files.Count.ToString());
                 }
@@ -226,7 +227,7 @@ namespace Dopamine.Services.File
 
                 await Task.Run(() =>
                 {
-                    lock (this.lockObject)
+                    lock (this.files)
                     {
                         // Sort the files in a natural way and clone the list
                         tempFiles = this.files.OrderByAlphaNumeric(item => item).Select(item => (string)item.Clone()).ToList();
@@ -264,13 +265,17 @@ namespace Dopamine.Services.File
             return decodeResult.Paths;
         }
 
-        private List<string> ProcessDirectory(string directoryPath)
+        private async Task<List<string>> ProcessDirectoryAsync(string directoryPath)
         {
             var folderPaths = new List<FolderPathInfo>();
 
             try
             {
-                folderPaths = FileOperations.GetValidFolderPaths(0, directoryPath, FileFormats.SupportedMediaExtensions);
+                folderPaths = await FileOperations.GetValidFolderPathsAsync(
+                    0,
+                    directoryPath,
+                    FileFormats.SupportedMediaExtensions,
+                    cancellationService.CancellationToken);
             }
             catch (Exception ex)
             {

--- a/Dopamine.Services/Lifetime/ITerminationService.cs
+++ b/Dopamine.Services/Lifetime/ITerminationService.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading;
+
+namespace Dopamine.Services.Lifetime
+{
+    public interface ITerminationService
+    {
+        bool Cancel();
+
+        CancellationToken CancellationToken { get; }
+
+        bool KeepRunning { get; }
+    }
+}

--- a/Dopamine.Services/Lifetime/TerminationService.cs
+++ b/Dopamine.Services/Lifetime/TerminationService.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading;
+
+namespace Dopamine.Services.Lifetime
+{
+    public class TerminationService : ITerminationService
+    {
+        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+        public CancellationToken CancellationToken
+        {
+            get => cancellationTokenSource.Token;
+        }
+
+        public bool KeepRunning
+        { 
+            get => !cancellationTokenSource.IsCancellationRequested;
+        }
+
+        public bool Cancel()
+        {
+            if(!cancellationTokenSource.IsCancellationRequested)
+            {
+                cancellationTokenSource.Cancel();
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Dopamine.Services/Metadata/MetadataService.cs
+++ b/Dopamine.Services/Metadata/MetadataService.cs
@@ -199,7 +199,7 @@ namespace Dopamine.Services.Metadata
             }
 
             // Update track fields
-            await Task.Run(() => MetadataUtils.FillTrackBase(fileMetadata, ref track));
+            await Task.Run(() => MetadataUtils.FillTrackBase(fileMetadata, track));
 
             // Update the Track in the database
             await this.trackRepository.UpdateTrackAsync(track);

--- a/Dopamine.Services/Update/IUpdateService.cs
+++ b/Dopamine.Services/Update/IUpdateService.cs
@@ -7,7 +7,7 @@ namespace Dopamine.Services.Update
 
     public interface IUpdateService
     {
-        void Reset();
+        Task Reset();
         void Dismiss();
         event UpdateAvailableEventHandler NewVersionAvailable;
         event EventHandler NoNewVersionAvailable;

--- a/Dopamine.Services/Update/UpdateService.cs
+++ b/Dopamine.Services/Update/UpdateService.cs
@@ -50,10 +50,10 @@ namespace Dopamine.Services.Update
             this.checkTimer.Elapsed += new ElapsedEventHandler(this.CheckTimerElapsedHandler);
         }
 
-        private void CheckTimerElapsedHandler(object sender, ElapsedEventArgs e)
+        private async void CheckTimerElapsedHandler(object sender, ElapsedEventArgs e)
         {
             this.checkTimer.Stop();
-            this.CheckNow();
+            await this.CheckNow();
         }
 
         private Package CreateDummyPackage()
@@ -249,7 +249,7 @@ namespace Dopamine.Services.Update
             return operationResult;
         }
 
-        private async void CheckNow()
+        private async Task CheckNow()
         {
             if (this.isDismissed)
             {
@@ -417,7 +417,7 @@ namespace Dopamine.Services.Update
             this.checkTimer.Stop();
         }
 
-        public void Reset()
+        public async Task Reset()
         {
             LogClient.Info("Resetting update check");
 
@@ -427,7 +427,7 @@ namespace Dopamine.Services.Update
 
             if (SettingsClient.Get<bool>("Updates", "CheckAtStartup"))
             {
-                this.CheckNow();
+                await this.CheckNow();
             }
             else if (SettingsClient.Get<bool>("Updates", "CheckPeriodically"))
             {

--- a/Dopamine.sln
+++ b/Dopamine.sln
@@ -1,9 +1,12 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2036
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30225.117
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B9EA6B1B-4B7E-4194-B858-24C4D70D9471}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dopamine.Packager", "Dopamine.Packager\Dopamine.Packager.csproj", "{F32533FD-96B4-4B94-8844-3EFA1F63F52A}"
 EndProject

--- a/Dopamine/App.xaml.cs
+++ b/Dopamine/App.xaml.cs
@@ -250,8 +250,9 @@ namespace Dopamine
                 containerRegistry.RegisterSingleton<IWindowsIntegrationService, WindowsIntegrationService>();
                 containerRegistry.RegisterSingleton<ILyricsService, LyricsService>();
                 containerRegistry.RegisterSingleton<IShellService, ShellService>();
-                containerRegistry.RegisterSingleton<ILifetimeService, LifetimeService>();
                 containerRegistry.RegisterSingleton<IInfoDownloadService, InfoDownloadService>();
+                containerRegistry.RegisterSingleton<ILifetimeService, LifetimeService>();
+                containerRegistry.RegisterSingleton<ITerminationService, TerminationService>();
 
                 INotificationService notificationService;
 

--- a/Dopamine/Dopamine.csproj
+++ b/Dopamine/Dopamine.csproj
@@ -140,7 +140,7 @@
       <HintPath>Libraries\taglib-sharp.dll</HintPath>
     </Reference>
     <Reference Include="Windows">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\Windows.winmd</HintPath>
+      <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\10.0.18362.0\Windows.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />

--- a/Dopamine/ViewModels/Common/Base/TracksViewModelBase.cs
+++ b/Dopamine/ViewModels/Common/Base/TracksViewModelBase.cs
@@ -45,6 +45,8 @@ namespace Dopamine.ViewModels.Common.Base
         private IProviderService providerService;
         private IPlaylistService playlistService;
         private IMetadataService metadataService;
+        private IQueuedTrackRepository queuedTrackRepository;
+
         private ObservableCollection<TrackViewModel> tracks;
         private CollectionViewSource tracksCvs;
         private IList<TrackViewModel> selectedTracks;
@@ -85,6 +87,7 @@ namespace Dopamine.ViewModels.Common.Base
             this.providerService = container.Resolve<IProviderService>();
             this.playlistService = container.Resolve<IPlaylistService>();
             this.metadataService = container.Resolve<IMetadataService>();
+            this.queuedTrackRepository = container.Resolve<IQueuedTrackRepository>();
 
             // Events
             this.metadataService.MetadataChanged += MetadataChangedHandlerAsync;
@@ -195,8 +198,13 @@ namespace Dopamine.ViewModels.Common.Base
             }
             else
             {
-                // Tracks have lowest priority
-                tracks = await this.trackRepository.GetTracksAsync();
+                tracks = await queuedTrackRepository.GetSavedQueuedTracksAsync();
+
+                if(tracks.Count == 0)
+                {
+                    // Tracks have lowest priority
+                    tracks = await this.trackRepository.GetTracksAsync();
+                }
             }
 
             await this.GetTracksCommonAsync(await this.container.ResolveTrackViewModelsAsync(tracks), trackOrder);

--- a/Dopamine/ViewModels/Common/UpdateStatusViewModel.cs
+++ b/Dopamine/ViewModels/Common/UpdateStatusViewModel.cs
@@ -61,7 +61,7 @@ namespace Dopamine.ViewModels.Common
             this.updateService.NewVersionAvailable += NewVersionAvailableHandler;
             this.updateService.NoNewVersionAvailable += NoNewVersionAvailableHandler;
 
-            this.LoadedCommand = new DelegateCommand(() => updateService.Reset());
+            this.LoadedCommand = new DelegateCommand(async () => await updateService.Reset());
         }
 
         private void NewVersionAvailableHandler(object sender, UpdateAvailableEventArgs e)

--- a/Dopamine/Views/Shell.xaml.cs
+++ b/Dopamine/Views/Shell.xaml.cs
@@ -122,7 +122,7 @@ namespace Dopamine.Views
             {
                 LogClient.Info("### STOPPING {0}, version {1} ###", ProductInformation.ApplicationName, ProcessExecutable.AssemblyVersion().ToString());
 
-                if (this.lifetimeService.MustPerformClosingTasks)
+                if(this.lifetimeService.MustPerformClosingTasks)
                 {
                     e.Cancel = true;
                     await this.lifetimeService.PerformClosingTasksAsync();


### PR DESCRIPTION
I like Dopamine a lot and it is my favorite music player on Windows 10. But I noticed considerable lags when using it with my music collection that resides on a network drive. It takes very long to scan all those titles and even after the whole library was scanned Dopamine still felt laggy in different areas like clicking on an artist or just quitting the application where it hung often.

So I looked at the code and found some areas which can be improved. I took a shot at trying to improve it and got the refresh of the library down from 174sec to 34sec (~80% speed up!).

Changes include:
- parallelized many stuff like retrieving the folder paths, updating the tracks, ...
- usage of SQLite to prevent generation of a lot of objects which need to be garbage collected
- added TerminationService to support cancelling of long-running tasks as fast as possible, especially upon termination
- activated foreign keys in SQLite database; QueuedTrack now just references Track instead of copying the path data
...

I don't expect this PR to merged as it is but if you want use it as a source of ideas to improve the performance of Dopamine.

Keep up the great work!