### PR TITLE
feat: support Discord Rich Presence

### DIFF
--- a/Dopamine.Core/Dopamine.Core.csproj
+++ b/Dopamine.Core/Dopamine.Core.csproj
@@ -50,11 +50,14 @@
     <Reference Include="Digimezzo.Foundation.WPF">
       <HintPath>..\Dopamine\Libraries\Digimezzo.Foundation.WPF.dll</HintPath>
     </Reference>
+    <Reference Include="DiscordRPC, Version=1.0.175.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
+    </Reference>
     <Reference Include="GongSolutions.WPF.DragDrop">
       <HintPath>..\Dopamine\Libraries\GongSolutions.WPF.DragDrop.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NVorbis">
       <HintPath>..\Dopamine\Libraries\NVorbis.dll</HintPath>

--- a/Dopamine.Core/packages.config
+++ b/Dopamine.Core/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net461" requireReinstallation="true" />
+  <package id="DiscordRichPresence" version="1.0.175" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
   <package id="Prism.Core" version="7.0.0.396" targetFramework="net461" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
   <package id="Unity" version="4.0.1" targetFramework="net461" />
 </packages>

--- a/Dopamine.Data/Dopamine.Data.csproj
+++ b/Dopamine.Data/Dopamine.Data.csproj
@@ -43,6 +43,12 @@
     <Reference Include="Digimezzo.Foundation.Core">
       <HintPath>..\Dopamine\Libraries\Digimezzo.Foundation.Core.dll</HintPath>
     </Reference>
+    <Reference Include="DiscordRPC, Version=1.0.175.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="Prism, Version=7.0.0.396, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.Core.7.0.0.396\lib\net45\Prism.dll</HintPath>
     </Reference>

--- a/Dopamine.Data/packages.config
+++ b/Dopamine.Data/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="DiscordRichPresence" version="1.0.175" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
   <package id="Prism.Core" version="7.0.0.396" targetFramework="net461" />
   <package id="sqlite-net-pcl" version="1.4.118" targetFramework="net461" />
   <package id="SQLitePCLRaw.bundle_green" version="1.1.9" targetFramework="net461" />

--- a/Dopamine.Packager/Dopamine.Packager.csproj
+++ b/Dopamine.Packager/Dopamine.Packager.csproj
@@ -51,6 +51,9 @@
     <Reference Include="Digimezzo.Foundation.Core">
       <HintPath>..\Dopamine\Libraries\Digimezzo.Foundation.Core.dll</HintPath>
     </Reference>
+    <Reference Include="DiscordRPC, Version=1.0.175.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
+    </Reference>
     <Reference Include="Ionic.Zip">
       <HintPath>..\Dopamine\Libraries\Ionic.Zip.dll</HintPath>
     </Reference>
@@ -62,6 +65,9 @@
     </Reference>
     <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Dopamine.Packager/packages.config
+++ b/Dopamine.Packager/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net461" requireReinstallation="true" />
+  <package id="DiscordRichPresence" version="1.0.175" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
 </packages>

--- a/Dopamine.Services/Discord/IRichPresenceService.cs
+++ b/Dopamine.Services/Discord/IRichPresenceService.cs
@@ -1,0 +1,7 @@
+﻿
+namespace Dopamine.Services.Discord
+{
+    public interface IRichPresenceService
+    {
+    }
+}

--- a/Dopamine.Services/Discord/RichPresenceService.cs
+++ b/Dopamine.Services/Discord/RichPresenceService.cs
@@ -1,0 +1,106 @@
+﻿using DiscordRPC;
+using Dopamine.Services.Playback;
+using System;
+
+namespace Dopamine.Services.Discord
+{
+    public class RichPresenceService : IRichPresenceService
+    {
+        protected const string ClientApplicationId = "825803781551030314";
+
+        protected DiscordRpcClient client;
+        protected IPlaybackService playbackService;
+
+        public RichPresenceService(IPlaybackService playbackService)
+        {
+            this.playbackService = playbackService;
+            this.Initialize();
+        }
+
+        /// <summary>
+        /// Registers the Discord client and the event handlers.
+        /// </summary>
+        private void Initialize()
+        {
+            this.client = new DiscordRpcClient(RichPresenceService.ClientApplicationId);
+            this.client.Initialize();
+            
+            this.playbackService.PlaybackResumed += this.HandleDetailsChanged;
+            this.playbackService.PlaybackSkipped += this.HandleDetailsChanged;
+            this.playbackService.PlaybackPaused += this.HandleDetailsChanged;
+            this.playbackService.PlayingTrackChanged += this.HandleDetailsChanged;
+            this.playbackService.PlaybackSuccess += this.HandleDetailsChanged;
+            this.playbackService.PlaybackStopped += this.HandleStop;
+        }
+
+        /// <summary>
+        /// Shows the current track's details.
+        /// </summary>
+        private void ShowTrackDetails()
+        {
+            RichPresence presence = new RichPresence()
+            {
+                Details = this.playbackService.CurrentTrack.TrackTitle,
+                State = $"by {this.playbackService.CurrentTrack.ArtistName}",
+                Assets = new Assets()
+                {
+                    LargeImageKey = "icon",
+                    LargeImageText = "Playing with Dopamine"
+                },
+            };
+
+            // If the track is playing, we show its remaining duration
+            // and an icon
+            if (this.playbackService.IsPlaying)
+            {
+                // Sets the duration
+                presence.WithTimestamps(new Timestamps()
+                {
+                    Start = DateTime.UtcNow,
+                    End = DateTime.UtcNow.AddMilliseconds(this.playbackService.CurrentTrack.Track.Duration.Value - this.playbackService.GetCurrentTime.TotalMilliseconds)
+                });
+
+                // Sets the "playing" image
+                presence.Assets.SmallImageKey = "play";
+                presence.Assets.SmallImageText = "Playing";
+            }
+
+            // If the track is paused, we don't set the timestamps and
+            // we show the appropriate icon
+            else
+            {
+                presence.Assets.SmallImageKey = "pause";
+                presence.Assets.SmallImageText = "Paused";
+            }
+
+
+            this.client.SetPresence(presence);
+        }
+
+        /// <summary>
+        /// Handles events that change the track's details.
+        /// </summary>
+        private void HandleDetailsChanged(object sender, EventArgs e)
+        {
+            this.ShowTrackDetails();
+        }
+
+        /// <summary>
+        /// Handles events that stop the track.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void HandleStop(object sender, EventArgs e)
+        {
+            this.client.ClearPresence();
+        }
+
+        /// <summary>
+        /// Dispose of the Discord client.
+        /// </summary>
+        ~RichPresenceService()
+        {
+            this.client.Dispose();
+        }
+    }
+}

--- a/Dopamine.Services/Dopamine.Services.csproj
+++ b/Dopamine.Services/Dopamine.Services.csproj
@@ -49,11 +49,14 @@
     <Reference Include="Digimezzo.Foundation.WPF">
       <HintPath>..\Dopamine\Libraries\Digimezzo.Foundation.WPF.dll</HintPath>
     </Reference>
+    <Reference Include="DiscordRPC, Version=1.0.175.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
+    </Reference>
     <Reference Include="Ionic.Zip">
       <HintPath>..\Dopamine\Libraries\Ionic.Zip.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Prism, Version=7.0.0.396, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.Core.7.0.0.396\lib\net45\Prism.dll</HintPath>
@@ -125,6 +128,8 @@
     <Compile Include="Dialog\NotificationDialog.xaml.cs">
       <DependentUpon>NotificationDialog.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Discord\IRichPresenceService.cs" />
+    <Compile Include="Discord\RichPresenceService.cs" />
     <Compile Include="Entities\AlbumViewModel.cs" />
     <Compile Include="Entities\ArtistViewModel.cs" />
     <Compile Include="Entities\FolderViewModel.cs" />

--- a/Dopamine.Services/app.config
+++ b/Dopamine.Services/app.config
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="CommonServiceLocator" publicKeyToken="489b6accfaf20ef0" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.3.0" newVersion="2.0.3.0"/>
+        <assemblyIdentity name="CommonServiceLocator" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.3.0" newVersion="2.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Prism" publicKeyToken="40ee6c3a2184dc59" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.396" newVersion="7.0.0.396"/>
+        <assemblyIdentity name="Prism" publicKeyToken="40ee6c3a2184dc59" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.396" newVersion="7.0.0.396" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" /></startup></configuration>

--- a/Dopamine.Services/packages.config
+++ b/Dopamine.Services/packages.config
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net461" requireReinstallation="true" />
-  <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net461" />
+  <package id="DiscordRichPresence" version="1.0.175" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
   <package id="Prism.Core" version="7.0.0.396" targetFramework="net461" />
   <package id="Prism.Wpf" version="7.0.0.336-pre" targetFramework="net461" />
   <package id="sqlite-net-pcl" version="1.4.118" targetFramework="net461" />

--- a/Dopamine.Tests/App.config
+++ b/Dopamine.Tests/App.config
@@ -1,6 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Prism" publicKeyToken="40ee6c3a2184dc59" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.396" newVersion="7.0.0.396" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/Dopamine.Tests/Dopamine.Tests.csproj
+++ b/Dopamine.Tests/Dopamine.Tests.csproj
@@ -49,6 +49,9 @@
     <Reference Include="Digimezzo.Foundation.Core">
       <HintPath>..\Dopamine\Libraries\Digimezzo.Foundation.Core.dll</HintPath>
     </Reference>
+    <Reference Include="DiscordRPC, Version=1.0.175.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Practices.Unity, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
       <Private>True</Private>
@@ -60,6 +63,9 @@
     <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention, Version=4.0.0.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\packages\Unity.4.0.1\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="policy.2.0.taglib-sharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=db62eba44689b5b0, processorArchitecture=MSIL">
       <HintPath>..\packages\taglib.2.1.0.0\lib\policy.2.0.taglib-sharp.dll</HintPath>

--- a/Dopamine.Tests/packages.config
+++ b/Dopamine.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net461" requireReinstallation="true" />
+  <package id="DiscordRichPresence" version="1.0.175" targetFramework="net472" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
   <package id="taglib" version="2.1.0.0" targetFramework="net461" />
 </packages>

--- a/Dopamine/App.config
+++ b/Dopamine/App.config
@@ -1,25 +1,29 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="CommonServiceLocator" publicKeyToken="489b6accfaf20ef0" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.3.0" newVersion="2.0.3.0"/>
+        <assemblyIdentity name="CommonServiceLocator" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.3.0" newVersion="2.0.3.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Prism" publicKeyToken="40ee6c3a2184dc59" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-7.0.0.396" newVersion="7.0.0.396"/>
+        <assemblyIdentity name="Prism" publicKeyToken="40ee6c3a2184dc59" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.396" newVersion="7.0.0.396" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Unity.Abstractions" publicKeyToken="6d32ff45e0ccc69f" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
+        <assemblyIdentity name="Unity.Abstractions" publicKeyToken="6d32ff45e0ccc69f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Unity.Container" publicKeyToken="489b6accfaf20ef0" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-5.7.3.0" newVersion="5.7.3.0"/>
+        <assemblyIdentity name="Unity.Container" publicKeyToken="489b6accfaf20ef0" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.7.3.0" newVersion="5.7.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Dopamine/App.xaml.cs
+++ b/Dopamine/App.xaml.cs
@@ -14,6 +14,7 @@ using Dopamine.Services.Cache;
 using Dopamine.Services.Collection;
 using Dopamine.Services.Command;
 using Dopamine.Services.Dialog;
+using Dopamine.Services.Discord;
 using Dopamine.Services.Equalizer;
 using Dopamine.Services.ExternalControl;
 using Dopamine.Services.File;
@@ -252,6 +253,7 @@ namespace Dopamine
                 containerRegistry.RegisterSingleton<IShellService, ShellService>();
                 containerRegistry.RegisterSingleton<ILifetimeService, LifetimeService>();
                 containerRegistry.RegisterSingleton<IInfoDownloadService, InfoDownloadService>();
+                containerRegistry.RegisterSingleton<IRichPresenceService, RichPresenceService>();
 
                 INotificationService notificationService;
 
@@ -299,6 +301,7 @@ namespace Dopamine
                     SettingsClient.Get<bool>("Appearance", "FollowAlbumCoverColor")
                 );
                 Container.Resolve<IExternalControlService>();
+                Container.Resolve<IRichPresenceService>();
             }
 
             void RegisterViews()

--- a/Dopamine/Dopamine.csproj
+++ b/Dopamine/Dopamine.csproj
@@ -80,12 +80,18 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Libraries\Digimezzo.Foundation.WPF.dll</HintPath>
     </Reference>
+    <Reference Include="DiscordRPC, Version=1.0.175.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
+    </Reference>
     <Reference Include="DryIoc, Version=2.12.8.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DryIoc.dll.2.12.8\lib\net45\DryIoc.dll</HintPath>
     </Reference>
     <Reference Include="GongSolutions.Wpf.DragDrop, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\gong-wpf-dragdrop.1.1.0\lib\net46\GongSolutions.Wpf.DragDrop.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Prism, Version=7.0.0.396, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.Core.7.0.0.396\lib\net45\Prism.dll</HintPath>
@@ -140,7 +146,7 @@
       <HintPath>Libraries\taglib-sharp.dll</HintPath>
     </Reference>
     <Reference Include="Windows">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Windows Kits\10\UnionMetadata\Windows.winmd</HintPath>
+      <HintPath>C:\Program Files (x86)\Windows Kits\10\UnionMetadata\Windows.winmd</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />

--- a/Dopamine/packages.config
+++ b/Dopamine/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="2.0.3" targetFramework="net461" />
+  <package id="DiscordRichPresence" version="1.0.175" targetFramework="net472" />
   <package id="DryIoc.dll" version="2.12.8" targetFramework="net461" />
   <package id="gong-wpf-dragdrop" version="1.1.0" targetFramework="net461" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net472" />
   <package id="Prism.Core" version="7.0.0.396" targetFramework="net461" />
   <package id="Prism.DryIoc" version="7.0.0.336-pre" targetFramework="net461" />
   <package id="Prism.Wpf" version="7.0.0.336-pre" targetFramework="net461" />


### PR DESCRIPTION
This pull request adds support for Discord's Rich Presence. It is powered by [Lachee's library](https://github.com/Lachee/discord-rpc-csharp). 

**Disclaimer**: I didn't write C# since years and this is the first time I'm contributing to a mature C# application. I am not aware of C#'s best practices, so I did my best and I apoligize if the code appears messy to you. 

My approach was to create a new service, registering it as a singleton, and listening to the `PlaybackService`'s events in order to update the Rich Presence.

**Things to consider:**
- Handling i18n - I wasn't sure if that was needed, as there are only four localized pieces of string. I think it would be a nice bonus.
- Creating your own [Discord application](https://discord.com/developers/applications). This is required in order to make the presence work. Image assets and the application's name are stored there. I won't delete mine, so the feature will work even if you don't, but I think that it would be better if *you* had full control over it. 
- Adding an option in the UI to enable or disable the Rich Presence.

**To create your app:**
- Go to the portal: https://discord.com/developers/applications
- Click `New application`
- Enter the name (eg. `Dopamine`)
- Optionally, upload your app icon (`[1]`)
- Click `Rich Presence` -> `Art Assets`
- Add the three images with their respective names (`icon`, `play` and `pause`: they are used in the code)

**Note**: the two icons are modified versions of Steve Schauger's [heroicons](https://heroicons.com/). They are under MIT.

**How it looks**

![](https://i.imgur.com/cX62HGq.png)
![](https://i.imgur.com/UEZkDmT.png)

**Assets**
[1] `icon`
![512x512](https://user-images.githubusercontent.com/16060559/112766936-68630e80-9014-11eb-96ff-88a5bdc0ba50.png)

[2] `play`
![play](https://user-images.githubusercontent.com/16060559/112766978-8e88ae80-9014-11eb-86ae-330ad5c8b95d.png)

[3] `pause`
![pause](https://user-images.githubusercontent.com/16060559/112766979-91839f00-9014-11eb-813f-4c4aaaf66d6b.png)

Closes https://github.com/digimezzo/dopamine-windows/issues/940
Closes https://github.com/digimezzo/dopamine-windows/issues/966
Closes https://github.com/digimezzo/dopamine-windows/issues/1027
Closes https://github.com/digimezzo/dopamine-windows/issues/1039