### PR TITLE
Add scrollbar to "Add to Playlist" menu for long item lists

### DIFF
--- a/Dopamine/Resources/Styles/DataGridTracks.xaml
+++ b/Dopamine/Resources/Styles/DataGridTracks.xaml
@@ -58,6 +58,34 @@
                     <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                 </CompositeCollection>
             </MenuItem.ItemsSource>
+            <MenuItem.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </MenuItem.ItemsPanel>
+            <MenuItem.Template>
+                <ControlTemplate TargetType="MenuItem">
+                    <Grid>
+                        <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                            <MenuItem.ItemsSource>
+                                <CompositeCollection>
+                                    <Separator/>
+                                </CompositeCollection>
+                            </MenuItem.ItemsSource>
+                        </MenuItem>
+                        <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                            <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                <Border.Effect>
+                                    <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                </Border.Effect>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <ItemsPresenter />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                </ControlTemplate>
+            </MenuItem.Template>
         </MenuItem>
         <Separator/>
         <MenuItem Header="{DynamicResource Language_Search_Online}" ItemsSource="{Binding DataContext.ContextMenuSearchProviders, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}" DisplayMemberPath="Name" IsEnabled="{Binding DataContext.HasContextMenuSearchProviders, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}">

--- a/Dopamine/Resources/Styles/ListBoxAlbums.xaml
+++ b/Dopamine/Resources/Styles/ListBoxAlbums.xaml
@@ -56,6 +56,34 @@
                     <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                 </CompositeCollection>
             </MenuItem.ItemsSource>
+            <MenuItem.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </MenuItem.ItemsPanel>
+            <MenuItem.Template>
+                <ControlTemplate TargetType="MenuItem">
+                    <Grid>
+                        <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                            <MenuItem.ItemsSource>
+                                <CompositeCollection>
+                                    <Separator/>
+                                </CompositeCollection>
+                            </MenuItem.ItemsSource>
+                        </MenuItem>
+                        <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                            <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                <Border.Effect>
+                                    <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                </Border.Effect>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <ItemsPresenter />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                </ControlTemplate>
+            </MenuItem.Template>
         </MenuItem>
         <Separator/>
         <MenuItem Header="{DynamicResource Language_Shuffle}" Command="{Binding DataContext.ShuffleSelectedAlbumsCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}">

--- a/Dopamine/Resources/Styles/ListBoxArtists.xaml
+++ b/Dopamine/Resources/Styles/ListBoxArtists.xaml
@@ -35,6 +35,34 @@
                     <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                 </CompositeCollection>
             </MenuItem.ItemsSource>
+            <MenuItem.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </MenuItem.ItemsPanel>
+            <MenuItem.Template>
+                <ControlTemplate TargetType="MenuItem">
+                    <Grid>
+                        <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                            <MenuItem.ItemsSource>
+                                <CompositeCollection>
+                                    <Separator/>
+                                </CompositeCollection>
+                            </MenuItem.ItemsSource>
+                        </MenuItem>
+                        <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                            <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                <Border.Effect>
+                                    <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                </Border.Effect>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <ItemsPresenter />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                </ControlTemplate>
+            </MenuItem.Template>
         </MenuItem>
         <Separator/>
         <MenuItem Header="{DynamicResource Language_Shuffle}" Command="{Binding DataContext.ShuffleSelectedArtistsCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}">

--- a/Dopamine/Resources/Styles/ListBoxGenres.xaml
+++ b/Dopamine/Resources/Styles/ListBoxGenres.xaml
@@ -19,7 +19,6 @@
             <utils:BindingProxy x:Key="NewPlaylistProxy" Data="{DynamicResource Language_New_Playlist}"/>
             <CollectionViewSource x:Key="PlaylistsDataSource" Source="{Binding DataContext.ContextMenuPlaylists, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}"/>
         </ContextMenu.Resources>
-
         <MenuItem Header="{DynamicResource Language_Add_To_Now_Playing}" InputGestureText="" Command="{Binding DataContext.AddGenresToNowPlayingCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}"/>
         <MenuItem Header="{DynamicResource Language_Add_To_Playlist}" DisplayMemberPath="Name">
             <MenuItem.ItemContainerStyle>
@@ -35,6 +34,34 @@
                     <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                 </CompositeCollection>
             </MenuItem.ItemsSource>
+            <MenuItem.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </MenuItem.ItemsPanel>
+            <MenuItem.Template>
+                <ControlTemplate TargetType="MenuItem">
+                    <Grid>
+                        <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                            <MenuItem.ItemsSource>
+                                <CompositeCollection>
+                                    <Separator/>
+                                </CompositeCollection>
+                            </MenuItem.ItemsSource>
+                        </MenuItem>
+                        <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                            <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                <Border.Effect>
+                                    <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                </Border.Effect>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <ItemsPresenter />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                </ControlTemplate>
+            </MenuItem.Template>
         </MenuItem>
         <Separator/>
         <MenuItem Header="{DynamicResource Language_Shuffle}" Command="{Binding DataContext.ShuffleSelectedGenresCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}">

--- a/Dopamine/Resources/Styles/ListBoxTracks.xaml
+++ b/Dopamine/Resources/Styles/ListBoxTracks.xaml
@@ -49,6 +49,34 @@
                     <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                 </CompositeCollection>
             </MenuItem.ItemsSource>
+            <MenuItem.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </MenuItem.ItemsPanel>
+            <MenuItem.Template>
+                <ControlTemplate TargetType="MenuItem">
+                    <Grid>
+                        <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                            <MenuItem.ItemsSource>
+                                <CompositeCollection>
+                                    <Separator/>
+                                </CompositeCollection>
+                            </MenuItem.ItemsSource>
+                        </MenuItem>
+                        <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                            <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                <Border.Effect>
+                                    <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                </Border.Effect>
+                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                    <ItemsPresenter />
+                                </ScrollViewer>
+                            </Border>
+                        </Popup>
+                    </Grid>
+                </ControlTemplate>
+            </MenuItem.Template>
         </MenuItem>
         <Separator/>
         <MenuItem Header="{DynamicResource Language_Search_Online}" ItemsSource="{Binding DataContext.ContextMenuSearchProviders, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}" DisplayMemberPath="Name" IsEnabled="{Binding DataContext.HasContextMenuSearchProviders, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}">

--- a/Dopamine/Views/Common/CollectionPlaybackControls.xaml
+++ b/Dopamine/Views/Common/CollectionPlaybackControls.xaml
@@ -47,6 +47,34 @@
                                     <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                                 </CompositeCollection>
                             </MenuItem.ItemsSource>
+                            <MenuItem.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <VirtualizingStackPanel />
+                                </ItemsPanelTemplate>
+                            </MenuItem.ItemsPanel>
+                            <MenuItem.Template>
+                                <ControlTemplate TargetType="MenuItem">
+                                    <Grid>
+                                        <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                                            <MenuItem.ItemsSource>
+                                                <CompositeCollection>
+                                                    <Separator/>
+                                                </CompositeCollection>
+                                            </MenuItem.ItemsSource>
+                                        </MenuItem>
+                                        <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                                            <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                                <Border.Effect>
+                                                    <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                                </Border.Effect>
+                                                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                                    <ItemsPresenter />
+                                                </ScrollViewer>
+                                            </Border>
+                                        </Popup>
+                                    </Grid>
+                                </ControlTemplate>
+                            </MenuItem.Template>
                         </MenuItem>
                     </ContextMenu>
                 </DockPanel.ContextMenu>

--- a/Dopamine/Views/Common/LyricsControl.xaml
+++ b/Dopamine/Views/Common/LyricsControl.xaml
@@ -217,6 +217,34 @@
                                 <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}" />
                             </CompositeCollection>
                         </MenuItem.ItemsSource>
+                        <MenuItem.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel />
+                            </ItemsPanelTemplate>
+                        </MenuItem.ItemsPanel>
+                        <MenuItem.Template>
+                            <ControlTemplate TargetType="MenuItem">
+                                <Grid>
+                                    <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                                        <MenuItem.ItemsSource>
+                                            <CompositeCollection>
+                                                <Separator/>
+                                            </CompositeCollection>
+                                        </MenuItem.ItemsSource>
+                                    </MenuItem>
+                                    <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                                        <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                            <Border.Effect>
+                                                <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                            </Border.Effect>
+                                            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                                <ItemsPresenter />
+                                            </ScrollViewer>
+                                        </Border>
+                                    </Popup>
+                                </Grid>
+                            </ControlTemplate>
+                        </MenuItem.Template>
                     </MenuItem>
                 </ContextMenu>
             </StackPanel.ContextMenu>

--- a/Dopamine/Views/MiniPlayer/CoverPlayer.xaml
+++ b/Dopamine/Views/MiniPlayer/CoverPlayer.xaml
@@ -67,6 +67,34 @@
                         <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                     </CompositeCollection>
                 </MenuItem.ItemsSource>
+                <MenuItem.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </MenuItem.ItemsPanel>
+                <MenuItem.Template>
+                    <ControlTemplate TargetType="MenuItem">
+                        <Grid>
+                            <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                                <MenuItem.ItemsSource>
+                                    <CompositeCollection>
+                                        <Separator/>
+                                    </CompositeCollection>
+                                </MenuItem.ItemsSource>
+                            </MenuItem>
+                            <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                                <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                    <Border.Effect>
+                                        <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                    </Border.Effect>
+                                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                        <ItemsPresenter />
+                                    </ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </ControlTemplate>
+                </MenuItem.Template>
             </MenuItem>
         </ContextMenu>
     </baseviews:MiniPlayerViewBase.ContextMenu>

--- a/Dopamine/Views/MiniPlayer/MicroPlayer.xaml
+++ b/Dopamine/Views/MiniPlayer/MicroPlayer.xaml
@@ -64,6 +64,34 @@
                         <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                     </CompositeCollection>
                 </MenuItem.ItemsSource>
+                <MenuItem.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </MenuItem.ItemsPanel>
+                <MenuItem.Template>
+                    <ControlTemplate TargetType="MenuItem">
+                        <Grid>
+                            <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                                <MenuItem.ItemsSource>
+                                    <CompositeCollection>
+                                        <Separator/>
+                                    </CompositeCollection>
+                                </MenuItem.ItemsSource>
+                            </MenuItem>
+                            <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                                <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                    <Border.Effect>
+                                        <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                    </Border.Effect>
+                                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                        <ItemsPresenter />
+                                    </ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </ControlTemplate>
+                </MenuItem.Template>
             </MenuItem>
         </ContextMenu>
     </baseviews:MiniPlayerViewBase.ContextMenu>

--- a/Dopamine/Views/MiniPlayer/NanoPlayer.xaml
+++ b/Dopamine/Views/MiniPlayer/NanoPlayer.xaml
@@ -64,6 +64,34 @@
                         <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                     </CompositeCollection>
                 </MenuItem.ItemsSource>
+                <MenuItem.ItemsPanel>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </MenuItem.ItemsPanel>
+                <MenuItem.Template>
+                    <ControlTemplate TargetType="MenuItem">
+                        <Grid>
+                            <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                                <MenuItem.ItemsSource>
+                                    <CompositeCollection>
+                                        <Separator/>
+                                    </CompositeCollection>
+                                </MenuItem.ItemsSource>
+                            </MenuItem>
+                            <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                                <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                    <Border.Effect>
+                                        <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                    </Border.Effect>
+                                    <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                        <ItemsPresenter />
+                                    </ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </ControlTemplate>
+                </MenuItem.Template>
             </MenuItem>
         </ContextMenu>
     </baseviews:MiniPlayerViewBase.ContextMenu>

--- a/Dopamine/Views/NowPlaying/NowPlayingPlaylist.xaml
+++ b/Dopamine/Views/NowPlaying/NowPlayingPlaylist.xaml
@@ -38,6 +38,34 @@
                                 <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                             </CompositeCollection>
                         </MenuItem.ItemsSource>
+                        <MenuItem.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <VirtualizingStackPanel />
+                            </ItemsPanelTemplate>
+                        </MenuItem.ItemsPanel>
+                        <MenuItem.Template>
+                            <ControlTemplate TargetType="MenuItem">
+                                <Grid>
+                                    <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                                        <MenuItem.ItemsSource>
+                                            <CompositeCollection>
+                                                <Separator/>
+                                            </CompositeCollection>
+                                        </MenuItem.ItemsSource>
+                                    </MenuItem>
+                                    <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                                        <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                            <Border.Effect>
+                                                <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                            </Border.Effect>
+                                            <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                                <ItemsPresenter />
+                                            </ScrollViewer>
+                                        </Border>
+                                    </Popup>
+                                </Grid>
+                            </ControlTemplate>
+                        </MenuItem.Template>
                     </MenuItem>
                 </ContextMenu>
             </StackPanel.ContextMenu>

--- a/Dopamine/Views/NowPlaying/NowPlayingShowcase.xaml
+++ b/Dopamine/Views/NowPlaying/NowPlayingShowcase.xaml
@@ -110,6 +110,34 @@
                             <CollectionContainer Collection="{Binding Source={StaticResource PlaylistsDataSource}}"/>
                         </CompositeCollection>
                     </MenuItem.ItemsSource>
+                    <MenuItem.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <VirtualizingStackPanel />
+                        </ItemsPanelTemplate>
+                    </MenuItem.ItemsPanel>
+                    <MenuItem.Template>
+                        <ControlTemplate TargetType="MenuItem">
+                            <Grid>
+                                <MenuItem Header="{Binding Header, RelativeSource={RelativeSource TemplatedParent}}" DisplayMemberPath="Name">
+                                    <MenuItem.ItemsSource>
+                                        <CompositeCollection>
+                                            <Separator/>
+                                        </CompositeCollection>
+                                    </MenuItem.ItemsSource>
+                                </MenuItem>
+                                <Popup IsOpen="{TemplateBinding IsSubmenuOpen}" Placement="Right" AllowsTransparency="True" PopupAnimation="Fade" HorizontalOffset="-23">
+                                    <Border BorderBrush="Transparent" BorderThickness="8,10,5,10" Background="White">
+                                        <Border.Effect>
+                                            <DropShadowEffect BlurRadius="8" Opacity="0.6" ShadowDepth="0" />
+                                        </Border.Effect>
+                                        <ScrollViewer VerticalScrollBarVisibility="Auto">
+                                            <ItemsPresenter />
+                                        </ScrollViewer>
+                                    </Border>
+                                </Popup>
+                            </Grid>
+                        </ControlTemplate>
+                    </MenuItem.Template>
                 </MenuItem>
             </ContextMenu>
         </DockPanel.ContextMenu>


### PR DESCRIPTION
I really enjoy using this software, but during my usage, I encountered a few minor issues that affected the user experience. I decided to attempt some fixes. However, I'm quite new to C#, so some parts of my implementation may not be the most elegant.  

---  

### Main Changes I Made  

For the **"Add to Playlist"** right-click option, when the playlist contains too many items, the display is limited by the screen size, showing only the first few playlists. The items beyond this limit become inaccessible. My changes primarily include:  

- **Customized the `MenuItem.Template`** to add a scrollbar for overly long lists, ensuring all options remain accessible.  

- **Adjusted shadow and offset settings** to closely replicate the original version's appearance.  

  > When the submenu opens on the right, its appearance is nearly identical to the original. However, when the submenu automatically adjusts to open on the left due to screen constraints, the offset I set only works for right-side popups. As a result, the gap between the submenu and its trigger is slightly larger than the original.  

---  

I understand that your focus is currently on developing the new version, so you might not have much time to review my code. Additionally, my implementation may not be the most refined. Nevertheless, I decided to create this pull request in hopes it can serve as a helpful example for others.  
